### PR TITLE
Added PDF generation at /permit/:system_id

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,6 @@ reporting/*.docx
 
 \#*
 .\#*
-
+.idea/*
+!private/.#pdf
 passenger.3000*

--- a/lib/mk_permit.js
+++ b/lib/mk_permit.js
@@ -1,0 +1,84 @@
+/**
+ * Created by TCummings on 8/27/2015.
+ */
+var phantom = Meteor.npmRequire('phantom');
+var fs = Meteor.npmRequire('fs');
+var shelljs = Meteor.npmRequire('shelljs');
+var pdfDirectory = process.env.PWD + '/private/.#pdf/';
+
+permit = {
+
+	download: function(req, res, system_id) {
+		var host = req.headers.host;
+		permit.createPDF("http://"+host+"/drawing/"+system_id+"/1", function(pdf1) {
+			permit.createPDF("http://"+host+"/drawing/"+system_id+"/2", function(pdf2) {
+				permit.createPDF("http://"+host+"/drawing/"+system_id+"/3", function(pdf3) {
+					permit.createPDF("http://"+host+"/drawing/"+system_id+"/4", function(pdf4) {
+						//TODO: Locate spec sheets
+						/* , 'data_sheets/' +'Suniva Optimus 60 Black 2014 01 17.pdf', 'data_sheets/' +'specsheet-1-igplusadvanced-86819.pdf'*/
+						permit.mergePDF([pdf1, pdf2, pdf3, pdf4 ], 'permit_' + system_id + (new Date()).valueOf() + '.pdf', function(pdf5) {
+							permit.downloadPDF(res, pdf5);
+						});
+					});
+				});
+			});
+		});
+	},
+
+	createPDF: function(url, callback) {
+		var planNumber = (new Date()).valueOf();
+		var pdfName = 'permit_'+planNumber+'.pdf';
+		console.log("createPDF(%s) %s", pdfName, url);
+
+		phantom.create(function (ph) {
+			ph.createPage(function (page) {
+				page.set('viewportSize', {width:2011,height:1554});
+				page.paperSize = {
+					width: '8.5in',
+					height: '11in'
+				};
+
+				page.open(url, function (status) {
+					console.log("createPDF(): Opening %s: %s", url, url, status);
+					console.log("createPDF() FileName: %s", pdfDirectory + pdfName);
+
+					page.render(pdfDirectory + pdfName, function() {
+						console.log('PDF File Created: ' + pdfName);
+						ph.exit();
+
+						if(callback) callback(pdfName);
+					});
+				});
+			});
+		});
+	},
+
+	downloadPDF: function(res, pdfName) {
+		var filePath = pdfDirectory + pdfName;
+		var stat = fs.statSync(filePath);
+
+		res.writeHead(200, {
+			'Content-Type': 'application/pdf',
+			'Content-Length': stat.size
+		});
+
+		fs.createReadStream(filePath).pipe(res);
+	},
+
+	mergePDF: function(inputFiles, outputFile, callback)
+	{
+
+		inputFiles.forEach(function(filename, i, inputFiles) { inputFiles[i] = pdfDirectory + inputFiles[i]; });
+
+		var options = {silent: true, async: this.async};
+		var command = 'gs -dBATCH -dNOPAUSE -q -sDEVICE=pdfwrite -sOutputFile=' + pdfDirectory + outputFile + " \'" + inputFiles.join("\' \'") + "\'";
+
+		console.log("Command: %s", command);
+		shelljs.exec(command, options, function (code, output) {
+			//TODO: Check for error
+
+			if(callback) callback(outputFile);  //pass result back to user supplied callback function
+		});
+
+	}
+};

--- a/lib/mk_permit.js
+++ b/lib/mk_permit.js
@@ -8,6 +8,12 @@ var pdfDirectory = process.env.PWD + '/private/.#pdf/';
 
 permit = {
 
+	/*****************************************************************************************************
+	 * Creates a permit for the passed system_id and serves it back to the user as a PDF download
+	 * @param {object} req - node http request object
+	 * @param {object} res - node http response object
+	 * @param {string} system_id - which system to generate a permit for
+	 *****************************************************************************************************/
 	download: function(req, res, system_id) {
 		var host = req.headers.host;
 		permit.createPDF("http://"+host+"/drawing/"+system_id+"/1", function(pdf1) {
@@ -25,6 +31,11 @@ permit = {
 		});
 	},
 
+	/*****************************************************************************************************
+	 * Renders the passed url using phantomjs and creates a PDF file
+	 * @param {string} url -  URL to render
+	 * @param {function} callback - called with the name of the newly created PDF file
+	 *****************************************************************************************************/
 	createPDF: function(url, callback) {
 		var planNumber = (new Date()).valueOf();
 		var pdfName = 'permit_'+planNumber+'.pdf';
@@ -53,6 +64,11 @@ permit = {
 		});
 	},
 
+	/*****************************************************************************************************
+	 * Sends the local PDF file to the user
+	 * @param {object} res - node http response object
+	 * @param {string} pdfName - filename of pdf (without directory)
+	 *****************************************************************************************************/
 	downloadPDF: function(res, pdfName) {
 		var filePath = pdfDirectory + pdfName;
 		var stat = fs.statSync(filePath);
@@ -65,6 +81,12 @@ permit = {
 		fs.createReadStream(filePath).pipe(res);
 	},
 
+	/*****************************************************************************************************
+	 * Takes a list of PDF files and merges them together to make one PDF.
+	 * @param {string[]} inputFiles - array of pdf file names to merge together, file names do not contain directory
+	 * @param {string} outputFile - name of pdf to create
+	 * @param {function} callback - called with name of newly created PDF
+	 *****************************************************************************************************/
 	mergePDF: function(inputFiles, outputFile, callback)
 	{
 

--- a/packages.json
+++ b/packages.json
@@ -1,5 +1,7 @@
 {
   "jsdom": "3.1.2",
   "wkhtmltopdf": "0.1.5",
-  "pdf-merge": "0.0.2"
+  "pdf-merge": "0.0.2",
+  "phantom": "0.7.2",
+  "shelljs": "0.5.3"
 }

--- a/packages/npm-container/.npm/package/npm-shrinkwrap.json
+++ b/packages/npm-container/.npm/package/npm-shrinkwrap.json
@@ -354,6 +354,61 @@
         }
       }
     },
+    "phantom": {
+      "version": "0.7.2",
+      "dependencies": {
+        "dnode": {
+          "version": "1.2.1",
+          "dependencies": {
+            "dnode-protocol": {
+              "version": "0.2.2"
+            },
+            "jsonify": {
+              "version": "0.0.0"
+            },
+            "weak": {
+              "version": "0.4.1",
+              "dependencies": {
+                "bindings": {
+                  "version": "1.2.1"
+                },
+                "nan": {
+                  "version": "1.8.4"
+                }
+              }
+            }
+          }
+        },
+        "shoe": {
+          "version": "0.0.15",
+          "dependencies": {
+            "sockjs": {
+              "version": "0.3.7",
+              "dependencies": {
+                "node-uuid": {
+                  "version": "1.3.3"
+                },
+                "faye-websocket": {
+                  "version": "0.4.4"
+                }
+              }
+            },
+            "sockjs-client": {
+              "version": "0.0.0-unreleasable"
+            }
+          }
+        },
+        "win-spawn": {
+          "version": "2.0.0"
+        },
+        "traverse": {
+          "version": "0.6.6"
+        }
+      }
+    },
+    "shelljs": {
+      "version": "0.5.3"
+    },
     "wkhtmltopdf": {
       "version": "0.1.5",
       "dependencies": {

--- a/private/.#pdf/.gitignore
+++ b/private/.#pdf/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/server/routes.js
+++ b/server/routes.js
@@ -32,7 +32,7 @@ Router.route('/drawing/:system_id', function () {
 
 },{
   name: 'drawing',
-  where: 'server',
+  where: 'server'
 });
 
 Router.route('/drawing/:system_id/:page', function () {
@@ -55,7 +55,7 @@ Router.route('/drawing/:system_id/:page', function () {
 
 },{
   name: 'drawing_page',
-  where: 'server',
+  where: 'server'
 });
 
 Router.route('/drawing/pdf_sample/:system_id', function () {
@@ -99,7 +99,7 @@ Router.route('/drawing/pdf_sample/:system_id', function () {
       marginBottom: 0,
       marginLeft: 0,
       marginRight: 0,
-      marginTop: 0,
+      marginTop: 0
     }
   ).pipe(
     response
@@ -110,5 +110,15 @@ Router.route('/drawing/pdf_sample/:system_id', function () {
 
 },{
   name: 'pdf_sample',
-  where: 'server',
+  where: 'server'
+});
+
+/*******************************************************************
+ * Serves the permit to the user as a PDF for the passed system_id
+ *******************************************************************/
+Router.route('/permit/:system_id', function () {
+	permit.download(this.request, this.response, this.params.system_id);
+},{
+	name: 'permit',
+	where: 'server'
 });


### PR DESCRIPTION
mk_permit.js generates the PDF permit for a system. Added phantomjs, and shelljs to create PDFs. Requires phantomjs 1.9.8 to be installed, and ghostscript to be installed.  Wasn't sure how to change the "download link", so I didn't change it.  But you can access the pdf by going to /permit/:system_id